### PR TITLE
Enable SSL redirect via Django

### DIFF
--- a/netbox/netbox/configuration_heroku.py
+++ b/netbox/netbox/configuration_heroku.py
@@ -21,6 +21,9 @@ DATABASE = dj_database_url.config()
 # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-SECRET_KEY
 SECRET_KEY = os.environ.get('SECRET_KEY', '')
 
+BASE_URL = os.environ.get('BASE_URL')
+SECURE_SSL_REDIRECT = os.environ.get('SECURE_SSL_REDIRECT', True)
+
 #########################
 #                       #
 #   Optional settings   #

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -46,6 +46,11 @@ BANNER_TOP = getattr(configuration, 'BANNER_TOP', '')
 BASE_PATH = getattr(configuration, 'BASE_PATH', '')
 if BASE_PATH:
     BASE_PATH = BASE_PATH.strip('/') + '/'  # Enforce trailing slash only
+
+burl = getattr(configuration, 'BASE_URL')
+if burl is not None:
+    BASE_URL = burl
+
 CHANGELOG_RETENTION = getattr(configuration, 'CHANGELOG_RETENTION', 90)
 CORS_ORIGIN_ALLOW_ALL = getattr(configuration, 'CORS_ORIGIN_ALLOW_ALL', False)
 CORS_ORIGIN_REGEX_WHITELIST = getattr(configuration, 'CORS_ORIGIN_REGEX_WHITELIST', [])
@@ -74,6 +79,7 @@ SHORT_TIME_FORMAT = getattr(configuration, 'SHORT_TIME_FORMAT', 'H:i:s')
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 WEBHOOKS_ENABLED = getattr(configuration, 'WEBHOOKS_ENABLED', False)
+SECURE_SSL_REDIRECT = getattr(configuration, 'SECURE_SSL_REDIRECT', False)
 
 CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
 


### PR DESCRIPTION
This enables a redirect for all non-ssl requests to SSL and possibly also sets the HSTS header via the Django security middleware.

**Important:** Set `BASE_URL` as an environment variable for this to work (e.g. `https://netbox.chaosdorf.space`)

### Background
Heroku will not automatically do this and also does not offer an option for this.

### Changes
- Allows setting this via the Netbox configuration file (default: off)
- Adds this option to the Heroku specific config - enabled by default for Heroku
